### PR TITLE
Normalizing the tournament table

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,9 @@
 {
     "semi": true,
     "singleQuote": true,
-    "singleAttributePerLine": false,
+    "singleAttributePerLine": true,
     "htmlWhitespaceSensitivity": "css",
-    "printWidth": 80,
+    "printWidth": 160,
     "plugins": [
         "prettier-plugin-tailwindcss"
     ],

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\UpdateTournamentRequest;
 use App\Models\Tournament;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 class TournamentController extends Controller
@@ -35,7 +36,27 @@ class TournamentController extends Controller
         $user_id = ['user_id' => Auth::id()];
 
         // attempt to create tournament
-        Tournament::create($request->safe()->merge($user_id)->toArray());
+        $tournament = Tournament::create($request->safe()->merge($user_id)->toArray());
+
+        // create links if there is any
+        $links = $request->safe()->only(['links']);
+
+        if ($links && $links['links']) {
+            $links = $links['links'];
+
+            DB::beginTransaction();
+
+            foreach ($links as $key => $value) {
+                $value['tournament_id'] = $tournament->id;
+                $value['created_at'] = now();
+                $value['updated_at'] = now();
+                $links[$key] = $value;
+            }
+
+            DB::table('tournament_links')->insert($links);
+
+            DB::commit();
+        }
 
         // redirect home
         return redirect()->to(route('landing'));
@@ -46,7 +67,7 @@ class TournamentController extends Controller
      */
     public function show(Tournament $tournament)
     {
-        $tournament->load('host');
+        $tournament->load(['host', 'links']);
 
         return Inertia::render('show-tournament', [
             'tournament' => $tournament,
@@ -58,6 +79,8 @@ class TournamentController extends Controller
      */
     public function edit(Tournament $tournament)
     {
+        $tournament->load('links');
+
         return Inertia::render('edit-tournament', [
             'tournament' => $tournament,
         ]);
@@ -69,6 +92,28 @@ class TournamentController extends Controller
     public function update(UpdateTournamentRequest $request, Tournament $tournament)
     {
         $tournament->update($request->validated());
+
+        // update links if there is any
+        $links = $request->safe()->only(['links']);
+
+        if ($links && $links['links']) {
+            $links = $links['links'];
+
+            DB::beginTransaction();
+
+            DB::table('tournament_links')->where('tournament_id', '=', $tournament->id)->delete();
+
+            foreach ($links as $key => $value) {
+                $value['tournament_id'] = $tournament->id;
+                $value['created_at'] = now();
+                $value['updated_at'] = now();
+                $links[$key] = $value;
+            }
+
+            DB::table('tournament_links')->insert($links);
+
+            DB::commit();
+        }
 
         return redirect()->to(route('landing'));
     }

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -51,9 +51,13 @@ class TournamentController extends Controller
                 $links[$key] = $value;
             }
 
-            DB::table('tournament_links')->insert($links);
+            try {
+                DB::table('tournament_links')->insert($links);
 
-            DB::commit();
+                DB::commit();
+            } catch (\Exception $e) {
+                DB::rollback();
+            }
         }
 
         // redirect home
@@ -99,16 +103,20 @@ class TournamentController extends Controller
 
             DB::beginTransaction();
 
-            DB::table('tournament_links')->where('tournament_id', '=', $tournament->id)->delete();
+            try {
+                DB::table('tournament_links')->where('tournament_id', '=', $tournament->id)->delete();
 
-            foreach ($links as $key => $value) {
-                $value['tournament_id'] = $tournament->id;
-                $links[$key] = $value;
+                foreach ($links as $key => $value) {
+                    $value['tournament_id'] = $tournament->id;
+                    $links[$key] = $value;
+                }
+
+                DB::table('tournament_links')->insert($links);
+
+                DB::commit();
+            } catch (\Exception $e) {
+                DB::rollback();
             }
-
-            DB::table('tournament_links')->insert($links);
-
-            DB::commit();
         }
 
         return redirect()->to(route('landing'));

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -48,8 +48,6 @@ class TournamentController extends Controller
 
             foreach ($links as $key => $value) {
                 $value['tournament_id'] = $tournament->id;
-                $value['created_at'] = now();
-                $value['updated_at'] = now();
                 $links[$key] = $value;
             }
 
@@ -105,8 +103,6 @@ class TournamentController extends Controller
 
             foreach ($links as $key => $value) {
                 $value['tournament_id'] = $tournament->id;
-                $value['created_at'] = now();
-                $value['updated_at'] = now();
                 $links[$key] = $value;
             }
 

--- a/app/Http/Requests/StoreTournamentRequest.php
+++ b/app/Http/Requests/StoreTournamentRequest.php
@@ -33,7 +33,6 @@ class StoreTournamentRequest extends FormRequest
             'end_datetime' => ['required', 'date', 'after:start_datetime'],
             'links.*.label' => ['required', 'string'],
             'links.*.url' => ['required', 'url'],
-            'links.*.sequence' => ['required', 'numeric'],
         ];
     }
 

--- a/app/Http/Requests/StoreTournamentRequest.php
+++ b/app/Http/Requests/StoreTournamentRequest.php
@@ -31,7 +31,9 @@ class StoreTournamentRequest extends FormRequest
             'min_rank' => ['required', 'numeric', 'gt:max_rank'],
             'start_datetime' => ['required', 'date'],
             'end_datetime' => ['required', 'date', 'after:start_datetime'],
-            'forum_post' => ['nullable', 'url', 'regex:/^https:\/\/osu.ppy.sh\/community\/forums\/topics\/\d+(\?n=\d+)?$/i'],
+            'links.*.label' => ['required', 'string'],
+            'links.*.url' => ['required', 'url'],
+            'links.*.sequence' => ['required', 'numeric'],
         ];
     }
 
@@ -44,6 +46,8 @@ class StoreTournamentRequest extends FormRequest
             'end_datetime.after' => 'The end date must be after the start date.',
             'min_rank.gt' => 'The min rank value must be higher than max rank.',
             'forum_post.regex' => 'The url must be an osu! Forum Post url.',
+            'links.*.label' => 'The label is required.',
+            'links.*.url' => 'The link must be a valid url.',
         ];
     }
 }

--- a/app/Http/Requests/UpdateTournamentRequest.php
+++ b/app/Http/Requests/UpdateTournamentRequest.php
@@ -31,7 +31,9 @@ class UpdateTournamentRequest extends FormRequest
             'min_rank' => ['required', 'numeric', 'gt:max_rank'],
             'start_datetime' => ['required', 'date'],
             'end_datetime' => ['required', 'date', 'after:start_datetime'],
-            'forum_post' => ['nullable', 'url', 'regex:/^https:\/\/osu.ppy.sh\/community\/forums\/topics\/\d+(\?n=\d+)?$/i'],
+            'links.*.label' => ['required', 'string'],
+            'links.*.url' => ['required', 'url'],
+            'links.*.sequence' => ['required', 'numeric'],
         ];
     }
 
@@ -43,7 +45,8 @@ class UpdateTournamentRequest extends FormRequest
         return [
             'end_datetime.after' => 'The end date must be after the start date.',
             'min_rank.gt' => 'The min rank value must be higher than max rank.',
-            'forum_post.regex' => 'The url must be an osu! Forum Post url.',
+            'links.*.label' => 'The label is required.',
+            'links.*.url' => 'The link must be a valid url.',
         ];
     }
 }

--- a/app/Http/Requests/UpdateTournamentRequest.php
+++ b/app/Http/Requests/UpdateTournamentRequest.php
@@ -33,7 +33,6 @@ class UpdateTournamentRequest extends FormRequest
             'end_datetime' => ['required', 'date', 'after:start_datetime'],
             'links.*.label' => ['required', 'string'],
             'links.*.url' => ['required', 'url'],
-            'links.*.sequence' => ['required', 'numeric'],
         ];
     }
 

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 #[Fillable(['user_id', 'name', 'caption', 'gamemode', 'max_rank', 'min_rank', 'start_datetime',
@@ -21,5 +22,13 @@ class Tournament extends Model
     public function host(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Get the external links of the tournament.
+     */
+    public function links(): HasMany
+    {
+        return $this->hasMany(TournamentLink::class);
     }
 }

--- a/app/Models/TournamentLink.php
+++ b/app/Models/TournamentLink.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-#[Fillable(['tournament_id', 'label', 'url', 'sequence'])]
+#[Fillable(['tournament_id', 'label', 'url'])]
 class TournamentLink extends Model
 {
     /**

--- a/app/Models/TournamentLink.php
+++ b/app/Models/TournamentLink.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[Fillable(['tournament_id', 'label', 'url', 'sequence'])]
 class TournamentLink extends Model
 {
     /**

--- a/app/Models/TournamentLink.php
+++ b/app/Models/TournamentLink.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TournamentLink extends Model
+{
+    /**
+     * Get the tournament the links belong to
+     */
+    public function tournament(): BelongsTo
+    {
+        return $this->belongsTo(Tournament::class);
+    }
+}

--- a/database/migrations/2026_04_13_094237_drop_several_columns_from_tournaments_table.php
+++ b/database/migrations/2026_04_13_094237_drop_several_columns_from_tournaments_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->dropColumn('forum_post');
+            $table->dropColumn('groupchat');
+            $table->dropColumn('groupchat_platform');
+            $table->dropColumn('livestream');
+            $table->dropColumn('livestream_platform');
+            $table->dropColumn('vod');
+            $table->dropColumn('vod_platform');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->string('forum_post')->nullable();
+
+            $table->string('groupchat')->nullable();
+            $table->string('groupchat_platform')->default('Discord');
+
+            $table->string('livestream')->nullable();
+            $table->string('livestream_platform')->default('Twitch');
+
+            $table->string('vod')->nullable();
+            $table->string('vod_platform')->default('YouTube');
+        });
+    }
+};

--- a/database/migrations/2026_04_13_095626_create_tournament_links_table.php
+++ b/database/migrations/2026_04_13_095626_create_tournament_links_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Tournament;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tournament_links', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Tournament::class)->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->string('url');
+            $table->integer('sequence');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tournament_links');
+    }
+};

--- a/database/migrations/2026_04_13_160650_drop_timestamps_from_tournament_links_table.php
+++ b/database/migrations/2026_04_13_160650_drop_timestamps_from_tournament_links_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tournament_links', function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tournament_links', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+};

--- a/database/migrations/2026_04_14_101509_drop_sequence_column_from_tournament_links_table.php
+++ b/database/migrations/2026_04_14_101509_drop_sequence_column_from_tournament_links_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tournament_links', function (Blueprint $table) {
+            $table->dropColumn('sequence');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tournament_links', function (Blueprint $table) {
+            $table->integer('sequence');
+        });
+    }
+};

--- a/resources/js/pages/create-tournament.tsx
+++ b/resources/js/pages/create-tournament.tsx
@@ -1,7 +1,24 @@
 import { store } from '@/routes/tournaments';
+import { Link } from '@/types/tournament';
 import { Form, Head } from '@inertiajs/react';
+import { useState } from 'react';
+
+const MAX_ROW = 5;
 
 export default function CreateTournament() {
+    const [links, setLinks] = useState<Link[]>([]);
+
+    const [nextId, setNextId] = useState<number>(0);
+
+    function addLink() {
+        setLinks([...links, { label: '', url: '', sequence: nextId + 1, id: nextId }]);
+        setNextId(nextId + 1);
+    }
+
+    function removeLink(link: Link) {
+        setLinks(links.filter((obj) => obj.id !== link.id));
+    }
+
     return (
         <>
             <Head title="Create Tournament" />
@@ -15,11 +32,13 @@ export default function CreateTournament() {
                 {({ errors, invalid, validate, processing }) => (
                     <>
                         <p className="mb-2">
-                            <span className="text-red-600">*</span> fields are
-                            required
+                            <span className="text-red-600">*</span> fields are required
                         </p>
 
-                        <label htmlFor="name" className="text-lg font-bold">
+                        <label
+                            htmlFor="name"
+                            className="text-lg font-bold"
+                        >
                             Tournament Name
                             <span className="text-red-600">*</span>
                         </label>
@@ -31,18 +50,14 @@ export default function CreateTournament() {
                             required
                             onChange={() => validate('name')}
                         />
-                        {invalid('name') && (
-                            <p className="text-red-600">{errors.name}</p>
-                        )}
+                        {invalid('name') && <p className="text-red-600">{errors.name}</p>}
 
                         <label
                             htmlFor="caption"
                             className="mt-4 text-lg font-bold"
                         >
                             Tournament Caption
-                            <span className="ml-1 text-sm text-gray-500">
-                                (optional, 255 characters max)
-                            </span>
+                            <span className="ml-1 text-sm text-gray-500">(optional, 255 characters max)</span>
                         </label>
                         <input
                             type="text"
@@ -51,9 +66,7 @@ export default function CreateTournament() {
                             placeholder="Ready to show your might?"
                             onChange={() => validate('caption')}
                         />
-                        {invalid('caption') && (
-                            <p className="text-red-600">{errors.caption}</p>
-                        )}
+                        {invalid('caption') && <p className="text-red-600">{errors.caption}</p>}
 
                         <label
                             htmlFor="gamemode"
@@ -73,9 +86,7 @@ export default function CreateTournament() {
                             <option value="taiko">Taiko</option>
                             <option value="ctb">Catch the Beat</option>
                         </select>
-                        {invalid('gamemode') && (
-                            <p className="text-red-600">{errors.gamemode}</p>
-                        )}
+                        {invalid('gamemode') && <p className="text-red-600">{errors.gamemode}</p>}
 
                         <div className="flex gap-4">
                             <div className="flex flex-1 flex-col">
@@ -94,11 +105,7 @@ export default function CreateTournament() {
                                     required
                                     onChange={() => validate('max_rank')}
                                 />
-                                {invalid('max_rank') && (
-                                    <p className="text-red-600">
-                                        {errors.max_rank}
-                                    </p>
-                                )}
+                                {invalid('max_rank') && <p className="text-red-600">{errors.max_rank}</p>}
                             </div>
 
                             <div className="flex flex-1 flex-col">
@@ -118,11 +125,7 @@ export default function CreateTournament() {
                                     required
                                     onChange={() => validate('min_rank')}
                                 />
-                                {invalid('min_rank') && (
-                                    <p className="text-red-600">
-                                        {errors.min_rank}
-                                    </p>
-                                )}
+                                {invalid('min_rank') && <p className="text-red-600">{errors.min_rank}</p>}
                             </div>
                         </div>
 
@@ -142,11 +145,7 @@ export default function CreateTournament() {
                                     required
                                     onChange={() => validate('start_datetime')}
                                 />
-                                {invalid('start_datetime') && (
-                                    <p className="text-red-600">
-                                        {errors.start_datetime}
-                                    </p>
-                                )}
+                                {invalid('start_datetime') && <p className="text-red-600">{errors.start_datetime}</p>}
                             </div>
 
                             <div className="flex flex-1 flex-col">
@@ -164,32 +163,88 @@ export default function CreateTournament() {
                                     required
                                     onChange={() => validate('end_datetime')}
                                 />
-                                {invalid('end_datetime') && (
-                                    <p className="text-red-600">
-                                        {errors.end_datetime}
-                                    </p>
-                                )}
+                                {invalid('end_datetime') && <p className="text-red-600">{errors.end_datetime}</p>}
                             </div>
                         </div>
 
-                        <label
-                            htmlFor="forum_post"
-                            className="mt-4 text-lg font-bold"
-                        >
-                            osu! Forum Post URL
-                            <span className="ml-1 text-sm text-gray-500">
-                                (optional)
-                            </span>
-                        </label>
-                        <input
-                            type="text"
-                            name="forum_post"
-                            className="rounded-md border border-slate-800 p-2"
-                            placeholder="https://osu.ppy.sh/community/forums/topics/..."
-                            onChange={() => validate('forum_post')}
-                        />
-                        {invalid('forum_post') && (
-                            <p className="text-red-600">{errors.forum_post}</p>
+                        <p className="mt-4 text-lg font-bold">Links</p>
+                        {links.map((link) => (
+                            <div
+                                key={link.id}
+                                id="links"
+                                className="mb-4 flex gap-2"
+                            >
+                                {links.length >= 2 && (
+                                    <button
+                                        type="button"
+                                        className="aspect-square h-10 place-self-end rounded-md bg-red-200 p-2 hover:cursor-pointer hover:bg-red-300"
+                                        onClick={() => removeLink(link)}
+                                    >
+                                        Del
+                                    </button>
+                                )}
+                                <div className="flex flex-1 gap-4">
+                                    <div className="flex-1">
+                                        <label htmlFor={'links[' + link.id + '][label]'}>Label</label>
+                                        <input
+                                            type="text"
+                                            name={'links[' + link.id + '][label]'}
+                                            id={'links[' + link.id + '][label]'}
+                                            className="block w-full rounded-md border border-slate-800 p-2"
+                                            required
+                                            onBlur={() => validate('links.' + link.id + '.label')}
+                                            defaultValue={links.find((obj) => obj.id === link.id)?.label}
+                                        />
+                                        {invalid('links.' + link.id + '.label') && <p className="text-red-600">{errors['links.' + link.id + '.label']}</p>}
+                                    </div>
+                                    <div className="flex-1">
+                                        <label htmlFor={'links[' + link.id + '][url]'}>URL</label>
+                                        <input
+                                            type="text"
+                                            name={'links[' + link.id + '][url]'}
+                                            id={'links[' + link.id + '][url]'}
+                                            className="flex w-full flex-1 rounded-md border border-slate-800 p-2"
+                                            required
+                                            onBlur={() => validate('links.' + link.id + '.url')}
+                                            defaultValue={links.find((obj) => obj.id === link.id)?.url}
+                                        />
+                                        {invalid('links.' + link.id + '.url') && <p className="text-red-600">{errors['links.' + link.id + '.url']}</p>}
+                                    </div>
+                                </div>
+                                {/* {links.length >= 2 && (
+                                    <div className="flex gap-2 place-self-end">
+                                        <button
+                                            type="button"
+                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                            disabled={link.sequence === 1}
+                                        >
+                                            Up
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                            disabled={link.sequence === MAX_ROW}
+                                        >
+                                            Down
+                                        </button>
+                                    </div>
+                                )} */}
+                                <input
+                                    type="hidden"
+                                    name={'links[' + link.id + '][sequence]'}
+                                    id={'links[' + link.id + '][sequence]'}
+                                    value={links.find((obj) => obj.id === link.id)?.id}
+                                />
+                            </div>
+                        ))}
+                        {links.length < MAX_ROW && (
+                            <button
+                                type="button"
+                                className="block aspect-square w-8 rounded-md bg-green-200 hover:cursor-pointer hover:bg-green-300"
+                                onClick={() => addLink()}
+                            >
+                                +
+                            </button>
                         )}
 
                         <button

--- a/resources/js/pages/create-tournament.tsx
+++ b/resources/js/pages/create-tournament.tsx
@@ -11,7 +11,7 @@ export default function CreateTournament() {
     const [nextId, setNextId] = useState<number>(0);
 
     function addLink() {
-        setLinks([...links, { label: '', url: '', sequence: nextId + 1, id: nextId }]);
+        setLinks([...links, { label: '', url: '', id: nextId }]);
         setNextId(nextId + 1);
     }
 
@@ -229,12 +229,6 @@ export default function CreateTournament() {
                                         </button>
                                     </div>
                                 )} */}
-                                <input
-                                    type="hidden"
-                                    name={'links[' + link.id + '][sequence]'}
-                                    id={'links[' + link.id + '][sequence]'}
-                                    value={links.find((obj) => obj.id === link.id)?.id}
-                                />
                             </div>
                         ))}
                         {links.length < MAX_ROW && (

--- a/resources/js/pages/create-tournament.tsx
+++ b/resources/js/pages/create-tournament.tsx
@@ -19,6 +19,59 @@ export default function CreateTournament() {
         setLinks(links.filter((obj) => obj.id !== link.id));
     }
 
+    const linkIndex = (link: Link) => links.findIndex((obj) => obj.id === link.id); // find the index of the link
+
+    const linkFilteredOut = (link: Link) => links.filter((obj) => obj.id !== link.id); // filter out the link from the list
+
+    function insertLink(link: Link, newIndex = linkIndex(link)) {
+        const filtered = linkFilteredOut(link);
+
+        const newLinks = [
+            ...filtered.slice(0, newIndex), // elements before insertion point
+            link,
+            ...filtered.slice(newIndex), // elements after insertion point
+        ];
+
+        setLinks(newLinks);
+    }
+
+    function move(link: Link, direction = 'up') {
+        const index = linkIndex(link);
+
+        let newIndex = -1;
+        switch (direction) {
+            case 'up':
+                if (index !== 0) {
+                    newIndex = index - 1;
+                }
+                break;
+            case 'down':
+                if (index !== links.length + 1) {
+                    newIndex = index + 1;
+                }
+                break;
+            default:
+                break;
+        }
+
+        const otherLink = links.at(newIndex) as Link;
+        [link.id, otherLink.id] = [otherLink.id, link.id];
+
+        insertLink(link, newIndex);
+    }
+
+    function setLabel(newLabel: string, link: Link) {
+        link.label = newLabel;
+
+        insertLink(link);
+    }
+
+    function setUrl(newUrl: string, link: Link) {
+        link.url = newUrl;
+
+        insertLink(link);
+    }
+
     return (
         <>
             <Head title="Create Tournament" />
@@ -45,10 +98,12 @@ export default function CreateTournament() {
                         <input
                             type="text"
                             name="name"
+                            id="name"
                             className="rounded-md border border-slate-800 p-2"
                             placeholder="Awesome Osu Tournament"
                             required
                             onChange={() => validate('name')}
+                            autoComplete="false"
                         />
                         {invalid('name') && <p className="text-red-600">{errors.name}</p>}
 
@@ -62,6 +117,7 @@ export default function CreateTournament() {
                         <input
                             type="text"
                             name="caption"
+                            id="caption"
                             className="rounded-md border border-slate-800 p-2"
                             placeholder="Ready to show your might?"
                             onChange={() => validate('caption')}
@@ -76,6 +132,7 @@ export default function CreateTournament() {
                         </label>
                         <select
                             name="gamemode"
+                            id="gamemode"
                             className="rounded-md border border-slate-800 p-2"
                             defaultValue="std"
                             required
@@ -100,6 +157,7 @@ export default function CreateTournament() {
                                 <input
                                     type="number"
                                     name="max_rank"
+                                    id="max_rank"
                                     className="rounded-md border border-slate-800 p-2"
                                     placeholder="10000"
                                     required
@@ -119,6 +177,7 @@ export default function CreateTournament() {
                                 <input
                                     type="number"
                                     name="min_rank"
+                                    id="min_rank"
                                     min={1}
                                     className="rounded-md border border-slate-800 p-2"
                                     placeholder="100000"
@@ -141,6 +200,7 @@ export default function CreateTournament() {
                                 <input
                                     type="datetime-local"
                                     name="start_datetime"
+                                    id="start_datetime"
                                     className="rounded-md border border-slate-800 p-2"
                                     required
                                     onChange={() => validate('start_datetime')}
@@ -159,6 +219,7 @@ export default function CreateTournament() {
                                 <input
                                     type="datetime-local"
                                     name="end_datetime"
+                                    id="end_datetime"
                                     className="rounded-md border border-slate-800 p-2"
                                     required
                                     onChange={() => validate('end_datetime')}
@@ -171,7 +232,6 @@ export default function CreateTournament() {
                         {links.map((link) => (
                             <div
                                 key={link.id}
-                                id="links"
                                 className="mb-4 flex gap-2"
                             >
                                 {links.length >= 2 && (
@@ -193,7 +253,8 @@ export default function CreateTournament() {
                                             className="block w-full rounded-md border border-slate-800 p-2"
                                             required
                                             onBlur={() => validate('links.' + link.id + '.label')}
-                                            defaultValue={links.find((obj) => obj.id === link.id)?.label}
+                                            value={link.label}
+                                            onChange={(e) => setLabel(e.target.value, link)}
                                         />
                                         {invalid('links.' + link.id + '.label') && <p className="text-red-600">{errors['links.' + link.id + '.label']}</p>}
                                     </div>
@@ -206,29 +267,34 @@ export default function CreateTournament() {
                                             className="flex w-full flex-1 rounded-md border border-slate-800 p-2"
                                             required
                                             onBlur={() => validate('links.' + link.id + '.url')}
-                                            defaultValue={links.find((obj) => obj.id === link.id)?.url}
+                                            value={link.url}
+                                            onChange={(e) => setUrl(e.target.value, link)}
                                         />
                                         {invalid('links.' + link.id + '.url') && <p className="text-red-600">{errors['links.' + link.id + '.url']}</p>}
                                     </div>
                                 </div>
-                                {/* {links.length >= 2 && (
+                                {links.length >= 2 && (
                                     <div className="flex gap-2 place-self-end">
-                                        <button
-                                            type="button"
-                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
-                                            disabled={link.sequence === 1}
-                                        >
-                                            Up
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
-                                            disabled={link.sequence === MAX_ROW}
-                                        >
-                                            Down
-                                        </button>
+                                        {link !== links.at(0) && (
+                                            <button
+                                                type="button"
+                                                className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                                onClick={() => move(link, 'up')}
+                                            >
+                                                Up
+                                            </button>
+                                        )}
+                                        {link !== links.at(-1) && (
+                                            <button
+                                                type="button"
+                                                className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                                onClick={() => move(link, 'down')}
+                                            >
+                                                Down
+                                            </button>
+                                        )}
                                     </div>
-                                )} */}
+                                )}
                             </div>
                         ))}
                         {links.length < MAX_ROW && (

--- a/resources/js/pages/edit-tournament.tsx
+++ b/resources/js/pages/edit-tournament.tsx
@@ -1,11 +1,28 @@
 import { update } from '@/routes/tournaments';
-import { Tournament } from '@/types/tournament';
+import { Link, Tournament } from '@/types/tournament';
 import { Form, Head } from '@inertiajs/react';
+import { useState } from 'react';
 
 interface EditTournamentProps {
     tournament: Tournament;
 }
+
+const MAX_ROW = 5; // for links
+
 export default function EditTournament({ tournament }: EditTournamentProps) {
+    const [links, setLinks] = useState<Link[]>(tournament.links);
+
+    const [nextId, setNextId] = useState<number>(links.length === 0 ? 0 : Math.max(...links.map((obj) => obj.id)) + 1); // ensures id won't cause conflict locally
+
+    function addLink() {
+        setLinks([...links, { label: '', url: '', sequence: nextId + 1, id: nextId }]);
+        setNextId(nextId + 1);
+    }
+
+    function removeLink(link: Link) {
+        setLinks(links.filter((obj) => obj.id !== link.id));
+    }
+
     return (
         <>
             <Head title="Edit Tournament" />
@@ -19,47 +36,46 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                 {({ errors, invalid, validate, processing }) => (
                     <>
                         <p className="mb-2">
-                            <span className="text-red-600">*</span> fields are
-                            required
+                            <span className="text-red-600">*</span> fields are required
                         </p>
 
-                        <label htmlFor="name" className="text-lg font-bold">
+                        <label
+                            htmlFor="name"
+                            className="text-lg font-bold"
+                        >
                             Tournament Name
                             <span className="text-red-600">*</span>
                         </label>
                         <input
                             type="text"
                             name="name"
+                            id="name"
                             className="rounded-md border border-slate-800 p-2"
                             placeholder="Awesome Osu Tournament"
                             required
-                            onChange={() => validate('name')}
+                            onBlur={() => validate('name')}
                             defaultValue={tournament.name}
+                            autoComplete="false"
                         />
-                        {invalid('name') && (
-                            <p className="text-red-600">{errors.name}</p>
-                        )}
+                        {invalid('name') && <p className="text-red-600">{errors.name}</p>}
 
                         <label
                             htmlFor="caption"
                             className="mt-4 text-lg font-bold"
                         >
                             Tournament Caption
-                            <span className="ml-1 text-sm text-gray-500">
-                                (optional, 255 characters max)
-                            </span>
+                            <span className="ml-1 text-sm text-gray-500">(optional, 255 characters max)</span>
                         </label>
                         <input
                             type="text"
                             name="caption"
+                            id="caption"
                             className="rounded-md border border-slate-800 p-2"
                             placeholder="Ready to show your might?"
-                            onChange={() => validate('caption')}
+                            onBlur={() => validate('caption')}
                             defaultValue={tournament.caption}
                         />
-                        {invalid('caption') && (
-                            <p className="text-red-600">{errors.caption}</p>
-                        )}
+                        {invalid('caption') && <p className="text-red-600">{errors.caption}</p>}
 
                         <label
                             htmlFor="gamemode"
@@ -69,19 +85,18 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                         </label>
                         <select
                             name="gamemode"
+                            id="gamemode"
                             className="rounded-md border border-slate-800 p-2"
                             defaultValue={tournament.gamemode}
                             required
-                            onChange={() => validate('gamemode')}
+                            onBlur={() => validate('gamemode')}
                         >
                             <option value="std">Standard</option>
                             <option value="mania">Mania</option>
                             <option value="taiko">Taiko</option>
                             <option value="ctb">Catch the Beat</option>
                         </select>
-                        {invalid('gamemode') && (
-                            <p className="text-red-600">{errors.gamemode}</p>
-                        )}
+                        {invalid('gamemode') && <p className="text-red-600">{errors.gamemode}</p>}
 
                         <div className="flex gap-4">
                             <div className="flex flex-1 flex-col">
@@ -95,17 +110,14 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                 <input
                                     type="number"
                                     name="max_rank"
+                                    id="max_rank"
                                     className="rounded-md border border-slate-800 p-2"
                                     placeholder="10000"
                                     required
-                                    onChange={() => validate('max_rank')}
+                                    onBlur={() => validate('max_rank')}
                                     defaultValue={tournament.max_rank}
                                 />
-                                {invalid('max_rank') && (
-                                    <p className="text-red-600">
-                                        {errors.max_rank}
-                                    </p>
-                                )}
+                                {invalid('max_rank') && <p className="text-red-600">{errors.max_rank}</p>}
                             </div>
 
                             <div className="flex flex-1 flex-col">
@@ -119,18 +131,15 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                 <input
                                     type="number"
                                     name="min_rank"
+                                    id="min_rank"
                                     min={1}
                                     className="rounded-md border border-slate-800 p-2"
                                     placeholder="100000"
                                     required
-                                    onChange={() => validate('min_rank')}
+                                    onBlur={() => validate('min_rank')}
                                     defaultValue={tournament.min_rank}
                                 />
-                                {invalid('min_rank') && (
-                                    <p className="text-red-600">
-                                        {errors.min_rank}
-                                    </p>
-                                )}
+                                {invalid('min_rank') && <p className="text-red-600">{errors.min_rank}</p>}
                             </div>
                         </div>
 
@@ -146,16 +155,13 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                 <input
                                     type="datetime-local"
                                     name="start_datetime"
+                                    id="start_datetime"
                                     className="rounded-md border border-slate-800 p-2"
                                     required
-                                    onChange={() => validate('start_datetime')}
+                                    onBlur={() => validate('start_datetime')}
                                     defaultValue={tournament.start_datetime.toString()}
                                 />
-                                {invalid('start_datetime') && (
-                                    <p className="text-red-600">
-                                        {errors.start_datetime}
-                                    </p>
-                                )}
+                                {invalid('start_datetime') && <p className="text-red-600">{errors.start_datetime}</p>}
                             </div>
 
                             <div className="flex flex-1 flex-col">
@@ -169,38 +175,93 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                 <input
                                     type="datetime-local"
                                     name="end_datetime"
+                                    id="end_datetime"
                                     className="rounded-md border border-slate-800 p-2"
                                     required
-                                    onChange={() => validate('end_datetime')}
+                                    onBlur={() => validate('end_datetime')}
                                     defaultValue={tournament.end_datetime.toString()}
                                 />
-                                {invalid('end_datetime') && (
-                                    <p className="text-red-600">
-                                        {errors.end_datetime}
-                                    </p>
-                                )}
+                                {invalid('end_datetime') && <p className="text-red-600">{errors.end_datetime}</p>}
                             </div>
                         </div>
 
-                        <label
-                            htmlFor="forum_post"
-                            className="mt-4 text-lg font-bold"
-                        >
-                            osu! Forum Post URL
-                            <span className="ml-1 text-sm text-gray-500">
-                                (optional)
-                            </span>
-                        </label>
-                        <input
-                            type="text"
-                            name="forum_post"
-                            className="rounded-md border border-slate-800 p-2"
-                            placeholder="https://osu.ppy.sh/community/forums/topics/..."
-                            onChange={() => validate('forum_post')}
-                            defaultValue={tournament.forum_post}
-                        />
-                        {invalid('forum_post') && (
-                            <p className="text-red-600">{errors.forum_post}</p>
+                        <p className="mt-4 text-lg font-bold">Links</p>
+                        {links.map((link) => (
+                            <div
+                                key={link.id}
+                                className="mb-4 flex gap-2"
+                            >
+                                {links.length >= 2 && (
+                                    <button
+                                        type="button"
+                                        className="aspect-square h-10 place-self-end rounded-md bg-red-200 p-2 hover:cursor-pointer hover:bg-red-300"
+                                        onClick={() => removeLink(link)}
+                                    >
+                                        Del
+                                    </button>
+                                )}
+                                <div className="flex flex-1 gap-4">
+                                    <div className="flex-1">
+                                        <label htmlFor={'links[' + link.id + '][label]'}>Label</label>
+                                        <input
+                                            type="text"
+                                            name={'links[' + link.id + '][label]'}
+                                            id={'links[' + link.id + '][label]'}
+                                            className="block w-full rounded-md border border-slate-800 p-2"
+                                            required
+                                            onBlur={() => validate('links.' + link.id + '.label')}
+                                            defaultValue={links.find((obj) => obj.id === link.id)?.label}
+                                        />
+                                        {invalid('links.' + link.id + '.label') && <p className="text-red-600">{errors['links.' + link.id + '.label']}</p>}
+                                    </div>
+                                    <div className="flex-1">
+                                        <label htmlFor={'links[' + link.id + '][url]'}>URL</label>
+                                        <input
+                                            type="text"
+                                            name={'links[' + link.id + '][url]'}
+                                            id={'links[' + link.id + '][url]'}
+                                            className="flex w-full flex-1 rounded-md border border-slate-800 p-2"
+                                            required
+                                            onBlur={() => validate('links.' + link.id + '.url')}
+                                            defaultValue={links.find((obj) => obj.id === link.id)?.url}
+                                        />
+                                        {invalid('links.' + link.id + '.url') && <p className="text-red-600">{errors['links.' + link.id + '.url']}</p>}
+                                    </div>
+                                </div>
+                                {/* {links.length >= 2 && (
+                                    <div className="flex gap-2 place-self-end">
+                                        <button
+                                            type="button"
+                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                            disabled={link.sequence === 1}
+                                        >
+                                            Up
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                            disabled={link.sequence === MAX_ROW}
+                                        >
+                                            Down
+                                        </button>
+                                    </div>
+                                )} */}
+                                <input
+                                    type="hidden"
+                                    name={'links[' + link.id + '][sequence]'}
+                                    id={'links[' + link.id + '][sequence]'}
+                                    value={links.find((obj) => obj.id === link.id)?.id}
+                                />
+                            </div>
+                        ))}
+                        {links.length < MAX_ROW && (
+                            <button
+                                type="button"
+                                className="block aspect-square w-8 rounded-md bg-green-200 hover:cursor-pointer hover:bg-green-300"
+                                onClick={() => addLink()}
+                            >
+                                +
+                            </button>
                         )}
 
                         <button

--- a/resources/js/pages/edit-tournament.tsx
+++ b/resources/js/pages/edit-tournament.tsx
@@ -23,6 +23,59 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
         setLinks(links.filter((obj) => obj.id !== link.id));
     }
 
+    const linkIndex = (link: Link) => links.findIndex((obj) => obj.id === link.id); // find the index of the link
+
+    const linkFilteredOut = (link: Link) => links.filter((obj) => obj.id !== link.id); // filter out the link from the list
+
+    function insertLink(link: Link, newIndex = linkIndex(link)) {
+        const filtered = linkFilteredOut(link);
+
+        const newLinks = [
+            ...filtered.slice(0, newIndex), // elements before insertion point
+            link,
+            ...filtered.slice(newIndex), // elements after insertion point
+        ];
+
+        setLinks(newLinks);
+    }
+
+    function move(link: Link, direction = 'up') {
+        const index = linkIndex(link);
+
+        let newIndex = -1;
+        switch (direction) {
+            case 'up':
+                if (index !== 0) {
+                    newIndex = index - 1;
+                }
+                break;
+            case 'down':
+                if (index !== links.length + 1) {
+                    newIndex = index + 1;
+                }
+                break;
+            default:
+                break;
+        }
+
+        const otherLink = links.at(newIndex) as Link;
+        [link.id, otherLink.id] = [otherLink.id, link.id];
+
+        insertLink(link, newIndex);
+    }
+
+    function setLabel(newLabel: string, link: Link) {
+        link.label = newLabel;
+
+        insertLink(link);
+    }
+
+    function setUrl(newUrl: string, link: Link) {
+        link.url = newUrl;
+
+        insertLink(link);
+    }
+
     return (
         <>
             <Head title="Edit Tournament" />
@@ -210,7 +263,8 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                             className="block w-full rounded-md border border-slate-800 p-2"
                                             required
                                             onBlur={() => validate('links.' + link.id + '.label')}
-                                            defaultValue={links.find((obj) => obj.id === link.id)?.label}
+                                            value={link.label}
+                                            onChange={(e) => setLabel(e.target.value, link)}
                                         />
                                         {invalid('links.' + link.id + '.label') && <p className="text-red-600">{errors['links.' + link.id + '.label']}</p>}
                                     </div>
@@ -223,29 +277,34 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                             className="flex w-full flex-1 rounded-md border border-slate-800 p-2"
                                             required
                                             onBlur={() => validate('links.' + link.id + '.url')}
-                                            defaultValue={links.find((obj) => obj.id === link.id)?.url}
+                                            value={link.url}
+                                            onChange={(e) => setUrl(e.target.value, link)}
                                         />
                                         {invalid('links.' + link.id + '.url') && <p className="text-red-600">{errors['links.' + link.id + '.url']}</p>}
                                     </div>
                                 </div>
-                                {/* {links.length >= 2 && (
+                                {links.length >= 2 && (
                                     <div className="flex gap-2 place-self-end">
-                                        <button
-                                            type="button"
-                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
-                                            disabled={link.sequence === 1}
-                                        >
-                                            Up
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
-                                            disabled={link.sequence === MAX_ROW}
-                                        >
-                                            Down
-                                        </button>
+                                        {link !== links.at(0) && (
+                                            <button
+                                                type="button"
+                                                className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                                onClick={() => move(link, 'up')}
+                                            >
+                                                Up
+                                            </button>
+                                        )}
+                                        {link !== links.at(-1) && (
+                                            <button
+                                                type="button"
+                                                className="aspect-square h-10 rounded-md bg-gray-200 p-2 hover:cursor-pointer hover:bg-gray-300"
+                                                onClick={() => move(link, 'down')}
+                                            >
+                                                Down
+                                            </button>
+                                        )}
                                     </div>
-                                )} */}
+                                )}
                             </div>
                         ))}
                         {links.length < MAX_ROW && (

--- a/resources/js/pages/edit-tournament.tsx
+++ b/resources/js/pages/edit-tournament.tsx
@@ -15,7 +15,7 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
     const [nextId, setNextId] = useState<number>(links.length === 0 ? 0 : Math.max(...links.map((obj) => obj.id)) + 1); // ensures id won't cause conflict locally
 
     function addLink() {
-        setLinks([...links, { label: '', url: '', sequence: nextId + 1, id: nextId }]);
+        setLinks([...links, { label: '', url: '', id: nextId }]);
         setNextId(nextId + 1);
     }
 
@@ -246,12 +246,6 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                         </button>
                                     </div>
                                 )} */}
-                                <input
-                                    type="hidden"
-                                    name={'links[' + link.id + '][sequence]'}
-                                    id={'links[' + link.id + '][sequence]'}
-                                    value={links.find((obj) => obj.id === link.id)?.id}
-                                />
                             </div>
                         ))}
                         {links.length < MAX_ROW && (

--- a/resources/js/pages/landing.tsx
+++ b/resources/js/pages/landing.tsx
@@ -24,11 +24,9 @@ export default function Landing({ tournaments, ownTournaments }: LandingProps) {
                 {tournament.max_rank} - {tournament.min_rank}
             </td>
             <td className="border p-2">
-                {tournament.start_datetime.toString()} -{' '}
-                {tournament.end_datetime.toString()}
+                {tournament.start_datetime.toString()} - {tournament.end_datetime.toString()}
             </td>
             <td className="border p-2">{tournament.status}</td>
-            <td className="border p-2">{tournament.forum_post}</td>
         </Link>
     ));
     const ownTournamentItems = ownTournaments.map((tournament: Tournament) => (
@@ -44,11 +42,9 @@ export default function Landing({ tournaments, ownTournaments }: LandingProps) {
                 {tournament.max_rank} - {tournament.min_rank}
             </td>
             <td className="border p-2">
-                {tournament.start_datetime.toString()} -{' '}
-                {tournament.end_datetime.toString()}
+                {tournament.start_datetime.toString()} - {tournament.end_datetime.toString()}
             </td>
             <td className="border p-2">{tournament.status}</td>
-            <td className="border p-2">{tournament.forum_post}</td>
             <td className="border p-2 text-center">
                 <Link
                     href={edit(tournament.id)}
@@ -82,16 +78,13 @@ export default function Landing({ tournaments, ownTournaments }: LandingProps) {
                         <th className="border p-4">Rank Range</th>
                         <th className="border p-4">Period</th>
                         <th className="border p-4">Status</th>
-                        <th className="border p-4">Forum Post</th>
                     </tr>
                 </thead>
                 <tbody>{tournamentItems}</tbody>
             </table>
             {auth.user && ownTournaments.length > 0 && (
                 <>
-                    <h1 className="mt-12 text-3xl font-bold">
-                        Your Tournaments
-                    </h1>
+                    <h1 className="mt-12 text-3xl font-bold">Your Tournaments</h1>
                     <table className="border-2">
                         <thead>
                             <tr>
@@ -100,7 +93,6 @@ export default function Landing({ tournaments, ownTournaments }: LandingProps) {
                                 <th className="border p-4">Rank Range</th>
                                 <th className="border p-4">Period</th>
                                 <th className="border p-4">Status</th>
-                                <th className="border p-4">Forum Post</th>
                                 <th className="border p-4">Actions</th>
                             </tr>
                         </thead>

--- a/resources/js/pages/show-tournament.tsx
+++ b/resources/js/pages/show-tournament.tsx
@@ -5,12 +5,20 @@ interface ShowTournamentProps {
     tournament: Tournament;
 }
 export default function ShowTournament({ tournament }: ShowTournamentProps) {
+    const linkItems = tournament.links.map((link) => (
+        <a
+            key={link.id}
+            href={link.url}
+            target="_blank"
+            className="block w-fit text-blue-500 hover:text-blue-700 hover:underline"
+        >
+            {link.label} - {link.url}
+        </a>
+    ));
     return (
         <>
             <Head title={tournament.name} />
-            <h1 className="text-4xl font-bold">
-                Tournament Name: {tournament.name}
-            </h1>
+            <h1 className="text-4xl font-bold">Tournament Name: {tournament.name}</h1>
             {tournament.caption && <p>{tournament.caption}</p>}
             <p>Host: {tournament.host.username}</p>
             <p>Gamemode: {tournament.gamemode}</p>
@@ -18,20 +26,11 @@ export default function ShowTournament({ tournament }: ShowTournamentProps) {
                 Rank range: {tournament.max_rank} - {tournament.min_rank}
             </p>
             <p>
-                Period: {tournament.start_datetime.toString()} -{' '}
-                {tournament.end_datetime.toString()}
+                Period: {tournament.start_datetime.toString()} - {tournament.end_datetime.toString()}
             </p>
             <p>Status: {tournament.status}</p>
-            <p>
-                Forum Post:{' '}
-                <a
-                    href={tournament.forum_post}
-                    className="text-blue-500 hover:text-blue-700 hover:underline"
-                    target="_blank"
-                >
-                    {tournament.forum_post}
-                </a>
-            </p>
+            <p>Links:</p>
+            {linkItems}
         </>
     );
 }

--- a/resources/js/types/tournament.ts
+++ b/resources/js/types/tournament.ts
@@ -18,6 +18,5 @@ export type Tournament = {
 export type Link = {
     label: string;
     url: string;
-    sequence: number;
     id: number;
 };

--- a/resources/js/types/tournament.ts
+++ b/resources/js/types/tournament.ts
@@ -12,5 +12,12 @@ export type Tournament = {
     start_datetime: Date;
     end_datetime: Date;
     status: TournamentStatus;
-    forum_post: string;
+    links: Link[];
+};
+
+export type Link = {
+    label: string;
+    url: string;
+    sequence: number;
+    id: number;
 };


### PR DESCRIPTION
1. Dropped `forum_post`, `groupchat`, `groupchat_platform`, `livestream`, `livestream_platform`, `vod`, `vod_platform` columns from `tournament` table
2. Created new `tournament_link` table consisting of `tournament_id`, `label`, and `url` columns
3. Set relationship to `Tournament` has many `TournamentLink` (i.e. one-to-many)
4. Updated `Prettier` config
5. Links reordering feature in `create-tournament.tsx` and `edit-tournament.tsx`