### PR TITLE
Created `MapPreviewer` component #18

### DIFF
--- a/resources/js/components/xeril/assembly-table.tsx
+++ b/resources/js/components/xeril/assembly-table.tsx
@@ -8,6 +8,7 @@ import { Form, router } from '@inertiajs/react';
 import { Trash2Icon } from 'lucide-react';
 import { disableFreemod, insertSuggestionToSlot, reenableFreemod, removeSuggestionFromSlot } from '@/routes/slots';
 import { overrideFreemodRules } from '@/routes/tournaments/pooling/slots/override';
+import MapPreviewer from './map-previewer';
 
 interface AssemblyTableProps {
     mappool: Mappool;
@@ -69,9 +70,17 @@ export default function AssemblyTable({ mappool, slots }: AssemblyTableProps) {
                         >
                             <Trash2Icon />
                         </button>
-                    ) : (
-                        <></>
-                    ),
+                    ) : null,
+            }),
+            columnHelper.display({
+                id: 'preview_button',
+                cell: (props) =>
+                    props.row.original.suggestion ? (
+                        <MapPreviewer
+                            beatmap_id={props.row.original.suggestion.beatmap.beatmap_id}
+                            mods={props.row.original.suggestion.beatmap.mods}
+                        />
+                    ) : null,
             }),
             columnHelper.accessor('slot', {
                 header: 'Slot',

--- a/resources/js/components/xeril/map-previewer.tsx
+++ b/resources/js/components/xeril/map-previewer.tsx
@@ -1,0 +1,61 @@
+import { XIcon } from 'lucide-react';
+import { useState } from 'react';
+
+interface MapPreviewerProps {
+    beatmap_id: number;
+    mods: string;
+}
+
+export default function MapPreviewer({ beatmap_id, mods }: MapPreviewerProps) {
+    const [showModal, setShowModal] = useState<boolean>(false);
+
+    let validMods = '';
+    mods.match(/.{2}/gi)?.forEach((mod) => {
+        switch (mod) {
+            case 'HD':
+                validMods += 'HD';
+                break;
+            case 'HR':
+                validMods += 'HR';
+                break;
+            case 'DT':
+                validMods += 'DT';
+                break;
+            case 'EZ':
+                validMods += 'EZ';
+                break;
+        }
+    });
+
+    return (
+        <>
+            <button
+                type="button"
+                className="cursor-pointer rounded-md bg-purple-200 px-2 py-1 hover:bg-purple-300"
+                onClick={() => setShowModal(true)}
+            >
+                Preview
+            </button>
+            {showModal && (
+                <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/80">
+                    <div className="w-full max-w-350 rounded-lg bg-white">
+                        <div className="relative flex flex-row items-center justify-center px-4">
+                            <h1 className="flex-1 border-b px-4 py-3 text-xl font-bold">{`Preview for ${beatmap_id} - ${mods}`}</h1>
+                            <button
+                                className="absolute right-4 cursor-pointer rounded-md hover:bg-black/20"
+                                onClick={() => setShowModal(false)}
+                            >
+                                <XIcon />
+                            </button>
+                        </div>
+
+                        <iframe
+                            className="aspect-video w-full"
+                            src={`https://preview.tryz.id.vn/?b=${beatmap_id}&m=${validMods}`}
+                        />
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/resources/js/components/xeril/suggestion-table.tsx
+++ b/resources/js/components/xeril/suggestion-table.tsx
@@ -10,6 +10,7 @@ import TagsCell from './tags-cell';
 import { useDraggable } from '@dnd-kit/react';
 import { ArrowUpIcon, ArrowDownIcon, ChevronsUpDownIcon } from 'lucide-react';
 import TagsHeader, { TagFilter } from './tags-header';
+import MapPreviewer from './map-previewer';
 
 interface SuggestionTableProps {
     tags: BeatmapTag[];
@@ -52,6 +53,16 @@ export default function SuggestionTable({ tags, suggestions, handleTagFilters }:
                     >
                         <Trash2Icon /> Delete
                     </button>
+                ),
+            }),
+            columnHelper.display({
+                id: 'preview_button',
+                header: 'Preview',
+                cell: (props) => (
+                    <MapPreviewer
+                        beatmap_id={props.row.original.beatmap.beatmap_id}
+                        mods={props.row.original.beatmap.mods}
+                    />
                 ),
             }),
             columnHelper.accessor('beatmap.beatmap_id', {


### PR DESCRIPTION
# Summary
I used `<iframe>` html component to load existing osu! beatmap previewer: https://preview.tryz.id.vn/
However, there is only standard game mode. There should be other gamemode existing previewer, or we could implement our own.