### PR TITLE
Implemented customize slots win condition

### DIFF
--- a/app/Enums/WinCondition.php
+++ b/app/Enums/WinCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum WinCondition: string
+{
+    case SCORE_V2 = 'Score V2';
+    case SCORE_V1 = 'Score V1';
+    case ACCURACY = 'Accuracy';
+    case COMBO = 'Combo';
+    case LEAST_MISS = 'Least Miss';
+}

--- a/app/Enums/WinCondition.php
+++ b/app/Enums/WinCondition.php
@@ -4,9 +4,20 @@ namespace App\Enums;
 
 enum WinCondition: string
 {
-    case SCORE_V2 = 'Score V2';
-    case SCORE_V1 = 'Score V1';
-    case ACCURACY = 'Accuracy';
-    case COMBO = 'Combo';
-    case LEAST_MISS = 'Least Miss';
+    case SCORE_V2 = 'score_v2';
+    case SCORE_V1 = 'score_v1';
+    case ACCURACY = 'accuracy';
+    case COMBO = 'combo';
+    case LEAST_MISS = 'least_miss';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SCORE_V2 => 'Score V2',
+            self::SCORE_V1 => 'Score V1',
+            self::ACCURACY => 'Accuracy',
+            self::COMBO => 'Combo',
+            self::LEAST_MISS => 'Least Miss',
+        };
+    }
 }

--- a/app/Http/Controllers/AssemblyController.php
+++ b/app/Http/Controllers/AssemblyController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Events\MappoolSlotUpdated;
+use App\Http\Requests\UpdateSlotWinConditionRequest;
 use App\Models\MappoolSlot;
 use App\Models\MappoolSuggestion;
 
@@ -52,6 +53,15 @@ class AssemblyController extends Controller
         $slot->update([
             'freemod_disabled' => false,
         ]);
+
+        broadcast(new MappoolSlotUpdated($slot));
+
+        return redirect()->back();
+    }
+
+    public function setWinCondition(UpdateSlotWinConditionRequest $request, MappoolSlot $slot)
+    {
+        $slot->update($request->safe()->only('win_condition'));
 
         broadcast(new MappoolSlotUpdated($slot));
 

--- a/app/Http/Controllers/PoolingController.php
+++ b/app/Http/Controllers/PoolingController.php
@@ -68,30 +68,32 @@ class PoolingController extends Controller
      */
     public function updateMappoolsFormat(UpdateMappoolFormatRequest $request, Tournament $tournament)
     {
-        foreach ($request->mappools as $mappool) {
-            $retrieved_mappool = Mappool::updateOrCreate([
-                'id' => $mappool['id'],
-                'tournament_id' => $tournament->id,
-            ],
-                [
-                    'round' => $mappool['round'],
-                    'slug' => Str::slug($mappool['round']),
-                    'star_rating' => (float) $mappool['star_rating'],
-                ]);
-
-            $formats = Arr::has($mappool, 'formats') ? $mappool['formats'] : [];
-            foreach ($formats as $format) {
-                MappoolFormat::updateOrCreate([
-                    'id' => $format['id'],
-                    'mappool_id' => $retrieved_mappool->id,
+        if (count($request->mappools) > 0) {
+            foreach ($request->mappools as $mappool) {
+                $retrieved_mappool = Mappool::updateOrCreate([
+                    'id' => $mappool['id'],
+                    'tournament_id' => $tournament->id,
                 ],
                     [
-                        'slot' => $format['slot'],
-                        'count' => $format['count'],
-                        'is_freemod' => $format['is_freemod'],
+                        'round' => $mappool['round'],
+                        'slug' => Str::slug($mappool['round']),
+                        'star_rating' => (float) $mappool['star_rating'],
                     ]);
-            }
 
+                $formats = Arr::has($mappool, 'formats') ? $mappool['formats'] : [];
+                foreach ($formats as $format) {
+                    MappoolFormat::updateOrCreate([
+                        'id' => $format['id'],
+                        'mappool_id' => $retrieved_mappool->id,
+                    ],
+                        [
+                            'slot' => $format['slot'],
+                            'count' => $format['count'],
+                            'is_freemod' => $format['is_freemod'],
+                        ]);
+                }
+
+            }
         }
 
         return redirect()->back();

--- a/app/Http/Requests/StoreTournamentRequest.php
+++ b/app/Http/Requests/StoreTournamentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Enums\Mode;
+use App\Enums\WinCondition;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -31,6 +32,7 @@ class StoreTournamentRequest extends FormRequest
             'min_rank' => ['required', 'numeric', 'gt:max_rank'],
             'start_datetime' => ['required', 'date'],
             'end_datetime' => ['required', 'date', 'after:start_datetime'],
+            'win_condition' => ['required', Rule::enum(WinCondition::class)],
             'links.*.label' => ['required', 'string'],
             'links.*.url' => ['required', 'url'],
         ];

--- a/app/Http/Requests/UpdateSlotWinConditionRequest.php
+++ b/app/Http/Requests/UpdateSlotWinConditionRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\WinCondition;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateSlotWinConditionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'win_condition' => ['required', Rule::enum(WinCondition::class)],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateTournamentRequest.php
+++ b/app/Http/Requests/UpdateTournamentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Enums\Mode;
+use App\Enums\WinCondition;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -31,6 +32,7 @@ class UpdateTournamentRequest extends FormRequest
             'min_rank' => ['required', 'numeric', 'gt:max_rank'],
             'start_datetime' => ['required', 'date'],
             'end_datetime' => ['required', 'date', 'after:start_datetime'],
+            'win_condition' => ['required', Rule::enum(WinCondition::class)],
             'links.*.label' => ['required', 'string'],
             'links.*.url' => ['required', 'url'],
         ];

--- a/app/Models/MappoolSlot.php
+++ b/app/Models/MappoolSlot.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-#[Fillable(['mappool_format_id', 'mappool_suggestion_id', 'slot', 'is_freemod', 'freemod_disabled'])]
+#[Fillable(['mappool_format_id', 'mappool_suggestion_id', 'slot', 'win_condition', 'is_freemod', 'freemod_disabled'])]
 #[WithoutTimestamps()]
 class MappoolSlot extends Model
 {

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-#[Fillable(['user_id', 'name', 'caption', 'mode', 'max_rank', 'min_rank', 'start_datetime', 'end_datetime', 'status', 'automatic_status_update', 'rules'])]
+#[Fillable(['user_id', 'name', 'caption', 'mode', 'max_rank', 'min_rank', 'start_datetime', 'end_datetime', 'win_condition', 'status', 'automatic_status_update', 'rules'])]
 class Tournament extends Model
 {
     use SoftDeletes;

--- a/app/Observers/MappoolFormatObserver.php
+++ b/app/Observers/MappoolFormatObserver.php
@@ -17,6 +17,7 @@ class MappoolFormatObserver
                 'mappool_format_id' => $mappoolFormat->id,
                 'slot' => $mappoolFormat->slot.($i),
                 'is_freemod' => $mappoolFormat->is_freemod,
+                'win_condition' => $mappoolFormat->mappool->tournament->win_condition,
             ]);
         }
     }
@@ -36,6 +37,7 @@ class MappoolFormatObserver
                 $slot->update([
                     'slot' => $mappoolFormat->slot.($number++),
                     'is_freemod' => $mappoolFormat->is_freemod,
+                    'win_condition' => $mappoolFormat->mappool->tournament->win_condition,
                 ]);
             }
 
@@ -45,6 +47,7 @@ class MappoolFormatObserver
                     'mappool_format_id' => $mappoolFormat->id,
                     'slot' => $mappoolFormat->slot.($number++),
                     'is_freemod' => $mappoolFormat->is_freemod,
+                    'win_condition' => $mappoolFormat->mappool->tournament->win_condition,
                 ]);
             }
 

--- a/database/migrations/2026_05_18_145531_add_win_condition_column_to_mappool_slots_table.php
+++ b/database/migrations/2026_05_18_145531_add_win_condition_column_to_mappool_slots_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('mappool_slots', function (Blueprint $table) {
+            $table->string('win_condition')->after('slot')->default('score_v2');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('mappool_slots', function (Blueprint $table) {
+            $table->dropColumn('win_condition');
+        });
+    }
+};

--- a/database/migrations/2026_05_18_145531_add_win_condition_column_to_mappool_slots_table.php
+++ b/database/migrations/2026_05_18_145531_add_win_condition_column_to_mappool_slots_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\WinCondition;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,7 +13,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('mappool_slots', function (Blueprint $table) {
-            $table->string('win_condition')->after('slot')->default('score_v2');
+            $table->string('win_condition')->after('slot')->default(WinCondition::SCORE_V2);
         });
     }
 

--- a/database/migrations/2026_05_18_163905_add_win_condition_column_to_tournaments_table.php
+++ b/database/migrations/2026_05_18_163905_add_win_condition_column_to_tournaments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\WinCondition;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->string('win_condition')->after('end_datetime')->default(WinCondition::SCORE_V2);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->dropColumn('win_condition');
+        });
+    }
+};

--- a/resources/js/components/xeril/assembly-table.tsx
+++ b/resources/js/components/xeril/assembly-table.tsx
@@ -9,7 +9,7 @@ import { Trash2Icon } from 'lucide-react';
 import { disableFreemod, insertSuggestionToSlot, reenableFreemod, removeSuggestionFromSlot } from '@/routes/slots';
 import { overrideFreemodRules } from '@/routes/tournaments/pooling/slots/override';
 import MapPreviewer from './map-previewer';
-import { ModeUtils } from '@/enums';
+import { ModeUtils, WinConditionUtils } from '@/enums';
 
 interface AssemblyTableProps {
     mappool: Mappool;
@@ -80,13 +80,17 @@ export default function AssemblyTable({ mappool, slots }: AssemblyTableProps) {
             columnHelper.accessor('slot', {
                 header: 'Slot',
             }),
+            columnHelper.accessor('win_condition', {
+                header: 'Win Con',
+                cell: (props) => WinConditionUtils.label(props.getValue()),
+            }),
             columnHelper.accessor('suggestion.beatmap.beatmap_id', {
                 header: 'Beatmap ID',
                 cell: (props) => props.row.original.suggestion?.beatmap.beatmap_id,
             }),
             columnHelper.accessor('suggestion.beatmap.mode', {
                 header: 'Mode',
-                cell: (props) => (props.row.original.suggestion ? <p>{ModeUtils.label(props.row.original.suggestion.beatmap.mode)}</p> : null),
+                cell: (props) => (props.row.original.suggestion ? <p>{ModeUtils.label(props.getValue())}</p> : null),
             }),
             columnHelper.accessor('suggestion.beatmap.mods', {
                 header: 'Mods',

--- a/resources/js/components/xeril/assembly-table.tsx
+++ b/resources/js/components/xeril/assembly-table.tsx
@@ -9,7 +9,8 @@ import { Trash2Icon } from 'lucide-react';
 import { disableFreemod, insertSuggestionToSlot, reenableFreemod, removeSuggestionFromSlot } from '@/routes/slots';
 import { overrideFreemodRules } from '@/routes/tournaments/pooling/slots/override';
 import MapPreviewer from './map-previewer';
-import { ModeUtils, WinConditionUtils } from '@/enums';
+import { ModeUtils } from '@/enums';
+import WinCondition from './win-condition';
 
 interface AssemblyTableProps {
     mappool: Mappool;
@@ -82,7 +83,7 @@ export default function AssemblyTable({ mappool, slots }: AssemblyTableProps) {
             }),
             columnHelper.accessor('win_condition', {
                 header: 'Win Con',
-                cell: (props) => WinConditionUtils.label(props.getValue()),
+                cell: (props) => <WinCondition slot={props.row.original} />,
             }),
             columnHelper.accessor('suggestion.beatmap.beatmap_id', {
                 header: 'Beatmap ID',

--- a/resources/js/components/xeril/win-condition.tsx
+++ b/resources/js/components/xeril/win-condition.tsx
@@ -1,4 +1,5 @@
 import { WinConditionUtils } from '@/enums';
+import { setWinCondition } from '@/routes/slots';
 import { Slot } from '@/types/mappools';
 import { Form } from '@inertiajs/react';
 import { useState } from 'react';
@@ -19,43 +20,51 @@ export default function WinCondition({ slot }: WinConditionProps) {
                 {WinConditionUtils.label(slot.win_condition)}
             </button>
             {showModal && (
-                <Form method="POST">
-                    <div
-                        className="fixed inset-0 z-4 h-screen w-screen bg-black/20"
-                        onClick={() => setShowModal(false)}
-                    />
-                    <div className="absolute top-1/2 left-1/2 z-5 -translate-1/2 bg-white">
-                        <h1 className="mx-4 mt-4 border-b-2 text-2xl font-semibold">Slot {slot.slot} Win Condition</h1>
-                        <select
-                            name="win_condition"
-                            className="my-6 p-2 focus:outline-0"
-                            defaultValue={slot.win_condition}
-                        >
-                            {WinConditionUtils.options().map((option) => (
-                                <option
-                                    key={option}
-                                    value={option}
-                                >
-                                    {WinConditionUtils.label(option)}
-                                </option>
-                            ))}
-                        </select>
-                        <div className="flex">
-                            <button
-                                type="submit"
-                                className="flex-1 cursor-pointer bg-green-200 p-2 hover:bg-green-300"
-                            >
-                                Save
-                            </button>
-                            <button
-                                type="button"
-                                className="flex-1 cursor-pointer bg-red-200 p-2 hover:bg-red-300"
+                <Form
+                    action={setWinCondition(slot)}
+                    onSuccess={() => setShowModal(false)}
+                >
+                    {({ processing }) => (
+                        <>
+                            <div
+                                className="fixed inset-0 z-4 h-screen w-screen bg-black/20"
                                 onClick={() => setShowModal(false)}
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    </div>
+                            />
+                            <div className="absolute top-1/2 left-1/2 z-5 -translate-1/2 bg-white">
+                                <h1 className="mx-4 mt-4 border-b-2 text-2xl font-semibold">Slot {slot.slot} Win Condition</h1>
+                                <select
+                                    name="win_condition"
+                                    className="my-6 p-2 focus:outline-0"
+                                    defaultValue={slot.win_condition}
+                                >
+                                    {WinConditionUtils.options().map((option) => (
+                                        <option
+                                            key={option}
+                                            value={option}
+                                        >
+                                            {WinConditionUtils.label(option)}
+                                        </option>
+                                    ))}
+                                </select>
+                                <div className="flex">
+                                    <button
+                                        type="submit"
+                                        className="flex-1 cursor-pointer bg-green-200 p-2 hover:bg-green-300 disabled:cursor-not-allowed"
+                                        disabled={processing}
+                                    >
+                                        Save
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="flex-1 cursor-pointer bg-red-200 p-2 hover:bg-red-300"
+                                        onClick={() => setShowModal(false)}
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        </>
+                    )}
                 </Form>
             )}
         </>

--- a/resources/js/components/xeril/win-condition.tsx
+++ b/resources/js/components/xeril/win-condition.tsx
@@ -1,0 +1,63 @@
+import { WinConditionUtils } from '@/enums';
+import { Slot } from '@/types/mappools';
+import { Form } from '@inertiajs/react';
+import { useState } from 'react';
+
+interface WinConditionProps {
+    slot: Slot;
+}
+
+export default function WinCondition({ slot }: WinConditionProps) {
+    const [showModal, setShowModal] = useState<boolean>(false);
+    return (
+        <>
+            <button
+                type="button"
+                className="cursor-pointer rounded-md bg-blue-200 hover:bg-blue-300"
+                onClick={() => setShowModal(true)}
+            >
+                {WinConditionUtils.label(slot.win_condition)}
+            </button>
+            {showModal && (
+                <Form method="POST">
+                    <div
+                        className="fixed inset-0 z-4 h-screen w-screen bg-black/20"
+                        onClick={() => setShowModal(false)}
+                    />
+                    <div className="absolute top-1/2 left-1/2 z-5 -translate-1/2 bg-white">
+                        <h1 className="mx-4 mt-4 border-b-2 text-2xl font-semibold">Slot {slot.slot} Win Condition</h1>
+                        <select
+                            name="win_condition"
+                            className="my-6 p-2 focus:outline-0"
+                            defaultValue={slot.win_condition}
+                        >
+                            {WinConditionUtils.options().map((option) => (
+                                <option
+                                    key={option}
+                                    value={option}
+                                >
+                                    {WinConditionUtils.label(option)}
+                                </option>
+                            ))}
+                        </select>
+                        <div className="flex">
+                            <button
+                                type="submit"
+                                className="flex-1 cursor-pointer bg-green-200 p-2 hover:bg-green-300"
+                            >
+                                Save
+                            </button>
+                            <button
+                                type="button"
+                                className="flex-1 cursor-pointer bg-red-200 p-2 hover:bg-red-300"
+                                onClick={() => setShowModal(false)}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                </Form>
+            )}
+        </>
+    );
+}

--- a/resources/js/pages/create-tournament.tsx
+++ b/resources/js/pages/create-tournament.tsx
@@ -1,4 +1,4 @@
-import { Mode, ModeUtils } from '@/enums';
+import { Mode, ModeUtils, WinCondition, WinConditionUtils } from '@/enums';
 import { storeTournament } from '@/routes/tournaments';
 import { Link } from '@/types/tournament';
 import { Form, Head } from '@inertiajs/react';
@@ -228,6 +228,28 @@ export default function CreateTournament() {
                                 {invalid('end_datetime') && <p className="text-red-600">{errors.end_datetime}</p>}
                             </div>
                         </div>
+
+                        <label className="mt-4">
+                            <p className="text-lg font-bold">
+                                Win Condition <span className="text-red-600">*</span>
+                            </p>
+
+                            <select
+                                name="win_condition"
+                                defaultValue={WinCondition.SCORE_V2}
+                                className="block rounded-md border border-black p-2 hover:outline-0 focus:outline-0"
+                            >
+                                {WinConditionUtils.options().map((option) => (
+                                    <option
+                                        key={option}
+                                        value={option}
+                                    >
+                                        {WinConditionUtils.label(option)}
+                                    </option>
+                                ))}
+                            </select>
+                            {invalid('win_condition') && <p className="text-red-600">{errors.win_condition}</p>}
+                        </label>
 
                         <p className="mt-4 text-lg font-bold">Links</p>
                         {links.map((link) => (

--- a/resources/js/pages/edit-tournament.tsx
+++ b/resources/js/pages/edit-tournament.tsx
@@ -1,4 +1,4 @@
-import { Mode, ModeUtils } from '@/enums';
+import { Mode, ModeUtils, WinConditionUtils } from '@/enums';
 import { updateTournament } from '@/routes/tournaments';
 import { Link, Tournament } from '@/types/tournament';
 import { Form, Head } from '@inertiajs/react';
@@ -238,6 +238,28 @@ export default function EditTournament({ tournament }: EditTournamentProps) {
                                 {invalid('end_datetime') && <p className="text-red-600">{errors.end_datetime}</p>}
                             </div>
                         </div>
+
+                        <label className="mt-4">
+                            <p className="text-lg font-bold">
+                                Win Condition <span className="text-red-600">*</span>
+                            </p>
+
+                            <select
+                                name="win_condition"
+                                defaultValue={tournament.win_condition}
+                                className="block rounded-md border border-black p-2 hover:outline-0 focus:outline-0"
+                            >
+                                {WinConditionUtils.options().map((option) => (
+                                    <option
+                                        key={option}
+                                        value={option}
+                                    >
+                                        {WinConditionUtils.label(option)}
+                                    </option>
+                                ))}
+                            </select>
+                            {invalid('win_condition') && <p className="text-red-600">{errors.win_condition}</p>}
+                        </label>
 
                         <p className="mt-4 text-lg font-bold">Links</p>
                         {links.map((link) => (

--- a/resources/js/pages/show-tournament.tsx
+++ b/resources/js/pages/show-tournament.tsx
@@ -40,6 +40,7 @@ export default function ShowTournament({ tournament }: ShowTournamentProps) {
             <p>
                 Period: {tournament.start_datetime.toString()} - {tournament.end_datetime.toString()}
             </p>
+            <p>Win Condition: {tournament.win_condition}</p>
             <p>Status: {tournament.status}</p>
             <p>Links:</p>
             {linkItems}

--- a/resources/js/pages/suggestions.tsx
+++ b/resources/js/pages/suggestions.tsx
@@ -241,6 +241,7 @@ export default function Suggestions({ tournament, mappool, tags, slots }: Sugges
         slot.suggestion = e.slot.suggestion;
         slot.mappool_suggestion_id = e.slot.mappool_suggestion_id;
         slot.freemod_disabled = e.slot.freemod_disabled;
+        slot.win_condition = e.slot.win_condition;
 
         updateSlotsState(slot);
     }

--- a/resources/js/types/mappools.ts
+++ b/resources/js/types/mappools.ts
@@ -1,3 +1,4 @@
+import { WinCondition } from '@/enums';
 import { FreemodRule } from './freemodrule';
 import { Suggestion } from './suggestion';
 
@@ -26,6 +27,7 @@ export type Slot = {
     mappool_suggestion_id: number;
     suggestion: Suggestion;
     slot: string;
+    win_condition: WinCondition;
     is_freemod: boolean;
     freemod_disabled: boolean;
     freemod_rules?: FreemodRule[];

--- a/resources/js/types/tournament.ts
+++ b/resources/js/types/tournament.ts
@@ -1,4 +1,4 @@
-import { Mode, TournamentStatus } from '@/enums';
+import { Mode, TournamentStatus, WinCondition } from '@/enums';
 import { User } from './auth';
 import { Mappool } from './mappools';
 
@@ -12,6 +12,7 @@ export type Tournament = {
     min_rank: number;
     start_datetime: Date;
     end_datetime: Date;
+    win_condition: WinCondition;
     status: TournamentStatus;
     links: Link[];
     mappools: Mappool[];

--- a/routes/tournament.php
+++ b/routes/tournament.php
@@ -53,4 +53,7 @@ Route::middleware('auth')->group(function () {
     // toggle freemod
     Route::post('/slots/{slot}/freemod/disable', [AssemblyController::class, 'disableFreemod'])->name('slots.disableFreemod');
     Route::post('/slots/{slot}/freemod/reenable', [AssemblyController::class, 'reenableFreemod'])->name('slots.reenableFreemod');
+
+    // win condition
+    Route::patch('/slots/{slot}/win_condition', [AssemblyController::class, 'setWinCondition'])->name('slots.setWinCondition');
 });


### PR DESCRIPTION
# Summary
It is now possible to customize per slot win condition. Currently available options: `Score V2`, `Score V1`, `Accuracy`, `Combo`, and `Least Miss`.

# Changes
1. Added `win_condition` column to `mappool_slots` and `tournaments` table
2. Added update form for validation
3. Added controller for win condition update logic
4. Added React components for handling win condition inside assembly table
5. Modified create and edit tournament form
6. Modified `Slot` and `Tournament` type
7. Modified `editMappoolFormat()` controller method to include safeguard